### PR TITLE
limit number of workers to 1

### DIFF
--- a/config/queue.php
+++ b/config/queue.php
@@ -38,7 +38,7 @@ return [
             'driver' => 'database',
             'table' => 'jobs',
             'queue' => 'default',
-            'retry_after' => 90,
+            'retry_after' => 20,
         ],
 
         'beanstalkd' => [

--- a/jobs.conf
+++ b/jobs.conf
@@ -1,9 +1,9 @@
 [program:laravel-worker]
 process_name=%(program_name)s_%(process_num)02d
-command=/usr/local/bin/php /var/www/html/artisan queue:work --tries=3 --sleep=10 --delay=30
+command=/usr/local/bin/php /var/www/html/artisan queue:work --tries=3 --sleep=10 --delay=20
 autostart=true
 autorestart=true
 user=root
-numprocs=4
+numprocs=1
 redirect_stderr=true
 stdout_logfile=/proc/1/fd/1


### PR DESCRIPTION
job concurrency was causing problems with nightbot oauth, this should be a quick fix